### PR TITLE
Fix client-trusted price in wblBuyweapon (free-money exploit)

### DIFF
--- a/lua/entities/weshop/init.lua
+++ b/lua/entities/weshop/init.lua
@@ -1977,13 +1977,100 @@ function CompressAndSendTable(netString, dataTable, ply)
 end
 
 
+-- Toggle for the anti-tamper honeypot/ban. Admins can disable the auto-ban
+-- entirely with `weshop_buy_antitamper 0` (it still ignores the spoofed price
+-- and charges the real cost; it just won't trap-and-ban).
+CreateConVar("weshop_buy_antitamper", "1", FCVAR_ARCHIVE, "WeShop: trap & ban clients that tamper with the buy net message (1) or just ignore the spoofed price (0).")
+
+-- Match a buy CLAIM (class + price off the wire) against the live catalogue.
+-- We compare on the (class, cost) PAIR, not class alone, because several
+-- catalogue entries can share one weapon class at different prices (e.g. the
+-- Grenade Mk1-7 all use weapon_rtbr_frag). Returns the matching entry, or nil
+-- when no legit entry sells that class at that price -> tampered message.
+local function WblMatchPurchase(class, price)
+	price = tonumber(price)
+	if not (class and price) then return nil end
+	for _, tier in ipairs(wblweaponlist) do
+		for _, weapon in ipairs(tier.weapons or {}) do
+			if weapon.class == class and tonumber(weapon.cost) == price then
+				return weapon
+			end
+		end
+	end
+	return nil
+end
+
+-- Issue the permaban. Routed through ULib (ULX) when present so the ban lands
+-- in ULX's ban list and an admin can lift it via `ulx unban` / XGUI; falls
+-- back to the engine ban (banned_user.cfg) on servers without ULX.
+local function WblBanTamperer(ply, sid, name, reason)
+	if ULib and ULib.ban and IsValid(ply) then
+		ULib.ban(ply, 0, reason, nil) -- 0 minutes = permanent, nil admin = console
+	elseif ULib and ULib.addBan then
+		ULib.addBan(sid, 0, reason, name, nil)
+	else
+		if IsValid(ply) then ply:Ban(0, true) end -- 0 = permanent, kick
+		RunConsoleCommand("banid", "0", sid, "kick")
+		RunConsoleCommand("writeid")
+	end
+end
+
+-- Honeypot: let the spoof appear to work for a few seconds, then permaban.
+local function WblTrapTamperer(ply, class, sentPrice)
+	if not (IsValid(ply) and ply:IsPlayer()) then return end
+	if ply.WblTrapped then return end -- one trip per session is plenty
+	ply.WblTrapped = true
+
+	local sid   = ply:SteamID()
+	local name  = ply:Nick()
+	local delay = math.random(5, 10)
+
+	-- Snapshot the real balance BEFORE the spoof "succeeds" so we can restore it
+	-- exactly at ban time. (changeMoney clamps to [0,max], so reverting via an
+	-- inverse delta wouldn't be exact under clamping; a snapshot always is.)
+	local before = ply:GetPData("wblmoney", -1)
+
+	-- Make it look like it worked: actually give the weapon and apply the
+	-- spoofed price. changeMoney caps gains at wblmonmax, so the live window is
+	-- bounded, and the restore below zeroes it out regardless.
+	local found = FindWeaponByClass(class)
+	GivePlayerWeapon(ply, class, sentPrice, found and found.Arsenaltype or "W")
+
+	MsgN(string.format("[WeShop] buy net-message TAMPER from %s <%s>: claimed price %s for '%s'. Permaban in %ds.",
+		name, sid, tostring(sentPrice), tostring(class), delay))
+
+	timer.Simple(delay, function()
+		if IsValid(ply) then
+			ply:SetPData("wblmoney", before)      -- roll back any ill-gotten gains
+			ply:SetPData("wblmoneyOld", before)
+		end
+		WblBanTamperer(ply, sid, name, "WeShop: tampering with the weapon-buy net message (price spoofing)")
+	end)
+end
+
 --for Buying Weapons
 net.Receive("wblBuyweapon", function(len, ply)
 	local price = net.ReadInt(32)
 	local weaponclass = net.ReadString()
-	local arsenaltype = net.ReadString()
-	wblDebug("Arsenaltype received from server: "..arsenaltype)
-	GivePlayerWeapon(ply, weaponclass, price, arsenaltype)
+	local arsenaltype = net.ReadString() -- read to drain the message; NOT trusted
+
+	-- The wire still carries the price (protocol unchanged), but the server now
+	-- treats it as a CLAIM to verify, never as authority. A genuine client
+	-- always echoes a real catalogue cost for the class it's buying.
+	local match = WblMatchPurchase(weaponclass, price)
+	if match then
+		-- Legit: charge the verified server-side cost & arsenal, never the wire.
+		wblDebug("Arsenaltype received from server: "..tostring(match.Arsenaltype))
+		GivePlayerWeapon(ply, weaponclass, match.cost, match.Arsenaltype)
+		return
+	end
+
+	-- No catalogue entry sells this (class, price): tampered net message
+	-- (negative "free money", arbitrary underpay, or bogus class).
+	if GetConVar("weshop_buy_antitamper"):GetBool() then
+		WblTrapTamperer(ply, weaponclass, price)
+	end
+	-- antitamper off: silently ignore the spoof, grant nothing.
 end)
 
 --for Buying 1 Primary Ammo


### PR DESCRIPTION
The weapon-buy net message let the client send the price, which the server passed straight into changeMoney(). A tampered net.WriteInt with a negative value (e.g. -5000000) minted money instead of spending it.

Server now verifies the claimed price against the live catalogue on the (class, cost) pair -- matching the pair rather than class alone so legit buys of duplicate-class variants (the Grenade Mk1-7 all share weapon_rtbr_frag at different costs) aren't false-flagged. Legit buys are charged the server-side cost and arsenal, never the wire value.

A mismatch (negative/arbitrary/underpay/bogus class) springs a honeypot: the spoof appears to work for a randomized 5-10s, then the player is permabanned and any ill-gotten balance is rolled back from a pre-exploit snapshot. The ban routes through ULib/ULX when present (so an admin can lift it via `ulx unban` / XGUI), falling back to the engine ban otherwise. Gated by the weshop_buy_antitamper convar (default 1).